### PR TITLE
Client에 커스텀 eslint rule를 추가합니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-prettier": "^4.0.0",
+    "eslint-webpack-plugin": "^4.0.0",
     "prettier": "^2.3.2",
     "typescript": "^4.9.5"
   }

--- a/packages/client/.eslintrc.js
+++ b/packages/client/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  extends: ['react-app', 'prettier'],
+  root: true,
+  env: {
+    node: true,
+  },
+  rules: {
+    'prefer-template': 1,
+    '@typescript-eslint/consistent-type-imports': 1,
+    'eqeqeq': [1, 'smart'],
+    //   '@typescript-eslint/interface-name-prefix': 'off',
+    //   '@typescript-eslint/explicit-function-return-type': 'off',
+    //   '@typescript-eslint/explicit-module-boundary-types': 'off',
+    //   '@typescript-eslint/no-explicit-any': 'off',
+  },
+};

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -49,11 +49,6 @@
     "@types/styled-components": "^5.1.26",
     "prettier": "^2.5.1"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3307,6 +3307,14 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
+"@types/eslint@^8.4.10":
+  version "8.21.1"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.21.1.tgz#110b441a210d53ab47795124dbc3e9bb993d1e7c"
+  integrity sha512-rc9K8ZpVjNcLs8Fp0dkozd5Pt2Apk1glO4Vgz8ix1u6yFByxfqo5Yavpy65o+93TAe24jr7v+eSBtFLvOQtCRQ==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
 "@types/estree@*":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz"
@@ -6127,7 +6135,7 @@ eslint-config-prettier@^8.3.0:
 
 eslint-config-react-app@^7.0.1:
   version "7.0.1"
-  resolved "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz#73ba3929978001c5c86274c017ea57eb5fa644b4"
   integrity sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==
   dependencies:
     "@babel/core" "^7.16.0"
@@ -6299,6 +6307,17 @@ eslint-webpack-plugin@^3.1.1:
   dependencies:
     "@types/eslint" "^7.29.0 || ^8.4.1"
     jest-worker "^28.0.2"
+    micromatch "^4.0.5"
+    normalize-path "^3.0.0"
+    schema-utils "^4.0.0"
+
+eslint-webpack-plugin@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-4.0.0.tgz#f77f37b2bbb8ad5c4197b5e55f5f2a49365a1a81"
+  integrity sha512-eM9ccGRWkU+btBSVfABRn8CjT7jZ2Q+UV/RfErMDVCFXpihEbvajNrLltZpwTAcEoXSqESGlEPIUxl7PoDlLWw==
+  dependencies:
+    "@types/eslint" "^8.4.10"
+    jest-worker "^29.4.1"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     schema-utils "^4.0.0"
@@ -8518,7 +8537,7 @@ jest-worker@^28.0.2:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest-worker@^29.4.2:
+jest-worker@^29.4.1, jest-worker@^29.4.2:
   version "29.4.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.4.2.tgz#d9b2c3bafc69311d84d94e7fb45677fc8976296f"
   integrity sha512-VIuZA2hZmFyRbchsUCHEehoSf2HEl0YVF8SDJqtPnKorAaBuh42V8QsLnde0XP5F6TyCynGPEGgBOn3Fc+wZGw==


### PR DESCRIPTION
## 배경

custom eslint rule을 추가합니다.
기존 react-app에 포함되어 있는 것을 기본셋팅으로 유지하며, 아래의 룰이 추가로 셋팅됩니다.
* type을 import 시에 자동으로 type import가 입력됩니다.
* 문자열을 더하는 연산시에 ``(string literer)으로 치환됩니다
* 값을 비교시에 === 을 기본으로 지정합니다