### PR TITLE
client영역에서 소켓을 사용하는 방법을 리펙토링합니다.

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -19,8 +19,6 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "@types/jest": "^27.5.2",
-    "@types/node": "^16.18.12",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "@types/react-router-dom": "^5.3.3",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,19 +3,26 @@ import Lobby from './pages/Lobby';
 import Room from './pages/Room';
 import Login from './pages/Login';
 import SignUp from './pages/SignUp';
+// !
+import * as Jotai from 'jotai';
+import { ClientSocketContextProvider } from './module/client-socket';
 
 function App() {
   return (
-    <div className="App">
+    <Jotai.Provider>
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Lobby />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/signup" element={<SignUp />} />
-          <Route path="/room" element={<Room />} />
-        </Routes>
+        <ClientSocketContextProvider>
+          <div className="App">
+            <Routes>
+              <Route path="/" element={<Lobby />} />
+              <Route path="/login" element={<Login />} />
+              <Route path="/signup" element={<SignUp />} />
+              <Route path="/room" element={<Room />} />
+            </Routes>
+          </div>
+        </ClientSocketContextProvider>
       </BrowserRouter>
-    </div>
+    </Jotai.Provider>
   );
 }
 

--- a/packages/client/src/app/atom.ts
+++ b/packages/client/src/app/atom.ts
@@ -1,16 +1,18 @@
 import { atom } from 'jotai';
 
-export const nickNameAtom = atom<string>('');
+//! 기본값에서 타입을 알 수 있기 때문에 타입을 명시하지 않아도 됩니다 ex<string> - @minhoyooDEV
+
+export const nickNameAtom = atom('');
 nickNameAtom.onMount = (onMountnickNameAtom) => {
   return () => onMountnickNameAtom('');
 };
 
-export const hostAtom = atom<boolean>(false);
+export const hostAtom = atom(false);
 hostAtom.onMount = (onMounthostAtom) => {
   return () => onMounthostAtom(false);
 };
 
-export const roomIdAtom = atom<string>('');
+export const roomIdAtom = atom('');
 roomIdAtom.onMount = (onMountroomIdAtom) => {
   return () => onMountroomIdAtom('');
 };

--- a/packages/client/src/app/peer.ts
+++ b/packages/client/src/app/peer.ts
@@ -12,7 +12,7 @@ export interface PeerState {
   pose: null | poseDetection.Pose;
 }
 
-const initialState = {
+const initialState: PeerState = {
   socketId: '',
   nickName: '',
   stream: null,
@@ -22,5 +22,5 @@ const initialState = {
   pose: null,
 };
 
-// Atoms
-export const peerAtom = atomWithReset<PeerState>(initialState);
+//!  이니셜타입에 해당 타입을 명시하면 추론이 가능하게 되어있네요 - @minhoyooDEV
+export const peerAtom = atomWithReset(initialState);

--- a/packages/client/src/components/inGame/InGame.tsx
+++ b/packages/client/src/components/inGame/InGame.tsx
@@ -20,7 +20,7 @@ import * as poseDetection from '@tensorflow-models/pose-detection';
 import { hostAtom } from '../../app/atom';
 import { peerAtom } from '../../app/peer';
 import { useResetAtom } from 'jotai/utils';
-import type { WrappedSocket } from '../../types/socket';
+import { useClientSocket } from '../../module/client-socket';
 
 const position = [
   ['left', 'top'],
@@ -76,7 +76,8 @@ export const scoreAtom = atom<number>(0);
 // };
 
 //todo socket, roomId, nickName 등 전역 관리 필요
-function InGame({ socket }: { socket: WrappedSocket }) {
+function InGame() {
+  const { socket } = useClientSocket();
   const host = useAtomValue(hostAtom);
   const videoRef = useRef<HTMLVideoElement>(null);
   const peer = useAtomValue(peerAtom);

--- a/packages/client/src/components/lobby/RoomList.tsx
+++ b/packages/client/src/components/lobby/RoomList.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import Poro from '../../assets/images/arcadePoro.png';
 import CreateRoom from '../lobby/roomList/CreateRoom';
 import type { WrappedSocket } from '../../types/socket';
+import { useClientSocket } from '../../module/client-socket';
 
 const RoomContainerWrapper = styled.div`
   display: flex;
@@ -71,19 +72,10 @@ const RoomCnt = styled.span`
   font-weight: 600;
 `;
 
-export default function RoomList({ socket }: { socket: WrappedSocket }) {
+export default function RoomList() {
   const navigate = useNavigate();
+  const { socket } = useClientSocket();
   const nickName = '정태욱'; //temp
-
-  useEffect(() => {
-    return () => {
-      socket.disconnect();
-    };
-  }, []);
-
-  useEffect(() => {
-    socket.on('connect', () => console.log('lobby socket connection complete.'));
-  }, []);
 
   const [rooms, setRooms] = useState<{
     [key: string]: {
@@ -105,12 +97,16 @@ export default function RoomList({ socket }: { socket: WrappedSocket }) {
     return () => window.removeEventListener('beforeunload', preventClose);
   }, []);
 
+  // ! 이 부분도 공통스테이트로 빼면 좋을 것 같습니다 - @minhoyooDEV
   useEffect(() => {
     socket.emit('rooms');
   }, []);
 
   useEffect(() => {
-    socket.on('get_rooms', (rooms) => setRooms(rooms));
+    socket.on('get_rooms', (rooms) => {
+      console.log(rooms);
+      setRooms(rooms);
+    });
   }, [rooms]);
 
   const joinRoom = (roomId: string) => {

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -1,13 +1,10 @@
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import * as Jotai from 'jotai';
 import './index.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   // <React.StrictMode>
-  <Jotai.Provider>
-    <App />
-  </Jotai.Provider>,
+  <App />,
   // </React.StrictMode>
 );

--- a/packages/client/src/module/client-socket/client-socket-context.tsx
+++ b/packages/client/src/module/client-socket/client-socket-context.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+import { useEffect } from 'react';
+import { useContext } from 'react';
+import { createContext } from 'react';
+import { clientSocket } from './socket-instance';
+
+interface ClientSocketContextProps {
+  socket: typeof clientSocket;
+}
+
+const socket = clientSocket;
+const clientSocketContext = createContext<ClientSocketContextProps | null>(null);
+
+interface ClientSocketContextProviderProps {
+  children: ReactNode;
+}
+const ClientSocketContextProvider = ({ children }: ClientSocketContextProviderProps) => {
+  useEffect(() => {
+    socket.on('connect', () => {
+      console.info('[🔌] 클라이언트의 소켓이 연결되었어요.');
+    });
+    return () => {
+      socket.disconnect();
+      console.info('[🔌] 클라이언트의 소켓이 끊어졌어요.');
+    };
+  }, []);
+
+  return <clientSocketContext.Provider value={{ socket }}>{children}</clientSocketContext.Provider>;
+};
+
+const useClientSocket = () => {
+  const ctx = useContext(clientSocketContext);
+  if (!ctx) {
+    throw new Error('clientSocket is not initialized');
+  }
+  return ctx;
+};
+
+export { ClientSocketContextProvider, useClientSocket };

--- a/packages/client/src/module/client-socket/client-socket-context.tsx
+++ b/packages/client/src/module/client-socket/client-socket-context.tsx
@@ -19,6 +19,7 @@ const ClientSocketContextProvider = ({ children }: ClientSocketContextProviderPr
     socket.on('connect', () => {
       console.info('[🔌] 클라이언트의 소켓이 연결되었어요.');
     });
+
     return () => {
       socket.disconnect();
       console.info('[🔌] 클라이언트의 소켓이 끊어졌어요.');

--- a/packages/client/src/module/client-socket/index.ts
+++ b/packages/client/src/module/client-socket/index.ts
@@ -1,0 +1,1 @@
+export * from './client-socket-context';

--- a/packages/client/src/module/client-socket/socket-instance.ts
+++ b/packages/client/src/module/client-socket/socket-instance.ts
@@ -1,0 +1,8 @@
+import { io } from 'socket.io-client';
+import type { ClientSocket } from './types';
+
+const SOCKET_SERVER_URL = 'http://localhost:8081';
+// const SOCKET_SERVER_URL = 'http://15.165.237.195:8081';
+const clientSocket: ClientSocket = io(SOCKET_SERVER_URL);
+
+export { clientSocket };

--- a/packages/client/src/module/client-socket/types.ts
+++ b/packages/client/src/module/client-socket/types.ts
@@ -1,0 +1,5 @@
+import type { Socket } from 'socket.io-client';
+import type { ServerToClientEvents, ClientToServerEvents } from 'project-types';
+
+// please note that the types are reversed
+export type ClientSocket = Socket<ServerToClientEvents, ClientToServerEvents>;

--- a/packages/client/src/pages/Lobby.tsx
+++ b/packages/client/src/pages/Lobby.tsx
@@ -1,14 +1,9 @@
 import RoomList from '../components/lobby/RoomList';
 import logo from '../assets/images/logo.png'; //temp
 import styled from 'styled-components';
-import { io } from 'socket.io-client';
-import { useEffect } from 'react';
 import { atom, useAtom } from 'jotai';
 import Loading from '../components/lobby/Loading';
 import { stream, detector } from '../utils/tfjs-movenet';
-
-// const SOCKET_SERVER_URL = 'http://localhost:8081';
-const SOCKET_SERVER_URL = 'http://15.165.237.195:8081';
 
 export const isLoadedAtom = atom(false);
 
@@ -22,14 +17,6 @@ const Logo = styled.img`
 
 function Lobby() {
   const [isLoaded, setIsLoaded] = useAtom(isLoadedAtom);
-  const socket = io(SOCKET_SERVER_URL);
-
-  useEffect(() => {
-    return () => {
-      socket.disconnect();
-      console.log('lobby socket disconnected.');
-    };
-  }, []);
 
   if (isLoaded && (!stream || !detector)) {
     setIsLoaded(false);
@@ -44,7 +31,7 @@ function Lobby() {
         <div>
           <Logo src={logo} />
           <hr />
-          <RoomList socket={socket} />
+          <RoomList />
         </div>
       )}
     </>

--- a/packages/client/src/pages/Room.tsx
+++ b/packages/client/src/pages/Room.tsx
@@ -1,6 +1,4 @@
 import { useLocation, useNavigate } from 'react-router-dom';
-import type { Socket } from 'socket.io-client';
-import { io } from 'socket.io-client';
 import { useEffect } from 'react';
 import InGame from '../components/inGame/InGame';
 import { stream, detector } from '../utils/tfjs-movenet';
@@ -9,15 +7,18 @@ import { useAtom, useSetAtom } from 'jotai';
 import { nickNameAtom, roomIdAtom } from '../app/atom';
 import { peerAtom } from '../app/peer';
 import { useResetAtom } from 'jotai/utils';
-
-// const SOCKET_SERVER_URL = 'http://localhost:8081';
-const SOCKET_SERVER_URL = 'http://15.165.237.195:8081';
+import { useClientSocket } from '../module/client-socket';
 
 //todo 주소로 직접 접근 시 홈(로그인)/로비 페이지로 redirect
 //todo stream이나 detector가 없다면 로비로 redirect
 
 function Room() {
   const navigate = useNavigate();
+
+  const { socket } = useClientSocket();
+
+  const location = useLocation();
+
   const [, setIsLoaded] = useAtom(isLoadedAtom);
   const setNickName = useSetAtom(nickNameAtom);
   const setRoomId = useSetAtom(roomIdAtom);
@@ -30,28 +31,20 @@ function Room() {
       setIsLoaded(false);
       navigate('/', { replace: true });
     }
-  }, []);
-
-  const location = useLocation();
-  setRoomId(location.state.roomId);
-  setNickName(location.state.nickName);
-
-  const socket: Socket = io(SOCKET_SERVER_URL);
-  console.log('room socket connection complete.');
-
-  useEffect(() => {
     return () => {
       resetPeer();
-      socket.disconnect();
-      console.log('room socket disconnected.');
     };
   }, []);
 
-  return (
-    <>
-      <InGame socket={socket} />
-    </>
-  );
+  useEffect(() => {
+    setNickName(location.state.nickName);
+  }, [location.state.nickName, setNickName]);
+
+  useEffect(() => {
+    setRoomId(location.state.roomId);
+  }, [location.state.roomId, setRoomId]);
+
+  return <InGame />;
 }
 
 export default Room;

--- a/packages/client/src/types/socket.ts
+++ b/packages/client/src/types/socket.ts
@@ -1,5 +1,6 @@
 import type { Socket } from 'socket.io-client';
 import type { ServerToClientEvents, ClientToServerEvents } from 'project-types';
 
-// please note that the types are reversed
+// ! module/client-socket/types 로 이동하였습니다 / 제거해주세요 - @minhoyooDEV
+
 export type WrappedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;

--- a/packages/project-types/src/socket.ts
+++ b/packages/project-types/src/socket.ts
@@ -37,6 +37,11 @@ export interface ServerToClientEvents {
 }
 
 export interface ClientToServerEvents {
+  /**
+   * rooms
+   * 방리스트에 대한 데이터를 요청합니다.
+   * 서버에서는 get_rooms 이벤트를 통해 응답합니다.
+   */
   rooms: () => void;
   create_room: (roomName: string) => void;
   join_room: (data: { roomId: string; nickName: string }) => void;

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -10,7 +10,8 @@ import mongoose from 'mongoose';
 @Module({
   imports: [
     ConfigModule.forRoot(),
-    MongooseModule.forRoot(process.env.MONGODB_URI, {
+    // MongooseModule.forRoot(process.env.MONGODB_URI, {
+    MongooseModule.forRoot('mongodb://localhost', {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3486,7 +3486,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@*", "@types/jest@^27.5.2":
+"@types/jest@*":
   version "27.5.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.5.2.tgz#ec49d29d926500ffb9fd22b84262e862049c026c"
   integrity sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==
@@ -3538,11 +3538,6 @@
   version "18.11.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
-
-"@types/node@^16.18.12":
-  version "16.18.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.12.tgz#e3bfea80e31523fde4292a6118f19ffa24fd6f65"
-  integrity sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw==
 
 "@types/offscreencanvas@~2019.3.0":
   version "2019.3.0"


### PR DESCRIPTION
## 내용

* 소켓을 context 객체로 올려서 connect와 disconnect의 관리를 글로벌하게 관리할 수 있도록 변경하였습니다
* reactrouter provider 아래에 있기 때문에 추가 hooks 구현으로 더 세부적인 관리도 가능합니다.